### PR TITLE
Append functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RtoSQLServerVersioning
 Title: Load R Dataframes into SQL Server Database Tables with System Versioning
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: c(
     person("Tom", "Wilson", email = "thomas.wilson@gov.scot", role = "cre"),
     person("Miles", "Drake", email = "miles.drake@gov.scot", role = "aut"),

--- a/R/drop_table.R
+++ b/R/drop_table.R
@@ -5,12 +5,13 @@
 #' @param schema Name of schema containing table to be dropped.
 #' @param table_name Name of the table to be dropped.
 #' @param versioned_table Is this a versioned table. Defaults to FALSE.
+#' @param silent If TRUE do not give message that dropping complete. Defaults to FALSE.
 #'
 #' @export
 #'
 #' @examples
 #' drop_table_from_db(database = "my_database", server = "my_server", schema = "my_schema", table_name = "table_to_drop")
-drop_table_from_db <- function(server, database, schema, table_name, versioned_table = FALSE) {
+drop_table_from_db <- function(server, database, schema, table_name, versioned_table = FALSE, silent = FALSE) {
   if (versioned_table) {
     check_sql <- paste0("select name, temporal_type, temporal_type_desc from sys.tables where name = '", table_name, "'")
     check_df <- execute_sql(server = server, database = database, sql = check_sql, output = TRUE)
@@ -31,5 +32,7 @@ drop_table_from_db <- function(server, database, schema, table_name, versioned_t
     drop_sql <- paste0("DROP TABLE [", schema, "].[", table_name, "]")
   }
   execute_sql(server = server, database = database, sql = drop_sql, output = TRUE)
-  message("Table: '", schema, ".", table_name, "' successfully deleted from database: '", database, "' on server '", server, "'")
+  if (!silent) {
+    message("Table: '", schema, ".", table_name, "' successfully deleted from database: '", database, "' on server '", server, "'")
+  }
 }

--- a/demo/00Index
+++ b/demo/00Index
@@ -1,0 +1,1 @@
+example_usage   example of loading a daily table to database

--- a/demo/example_usage.R
+++ b/demo/example_usage.R
@@ -60,13 +60,14 @@ if (file.exists(csv_fp)) {
   # Write current date dataframe to db -------------------------------------------------------
 
 
-  # Write the dataframe to a SQL Server table in batches of 100,000 rows at a time
+  # Write the dataframe to a SQL Server table in batches of 100,000 rows at a time - note over-writing, not appending here
   write_dataframe_to_db(
     database = database,
     server = server,
     schema = schema,
     table_name = paste0(db_prefix, str_replace_all(date_today, "-", "_")),
     dataframe = source_df,
+    append_to_existing = FALSE
     batch_size = 1e5,
     versioned_table = FALSE
   )

--- a/man/drop_table_from_db.Rd
+++ b/man/drop_table_from_db.Rd
@@ -9,7 +9,8 @@ drop_table_from_db(
   database,
   schema,
   table_name,
-  versioned_table = FALSE
+  versioned_table = FALSE,
+  silent = FALSE
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ drop_table_from_db(
 \item{table_name}{Name of the table to be dropped.}
 
 \item{versioned_table}{Is this a versioned table. Defaults to FALSE.}
+
+\item{silent}{If TRUE do not give message that dropping complete. Defaults to FALSE.}
 }
 \description{
 Drop SQL Server table from database. Check if versioned table and disable versioning and drop history table too if so.

--- a/man/write_dataframe_to_db.Rd
+++ b/man/write_dataframe_to_db.Rd
@@ -10,6 +10,7 @@ write_dataframe_to_db(
   schema,
   table_name,
   dataframe,
+  append_to_existing = FALSE,
   batch_size = 1e+05,
   versioned_table = FALSE
 )
@@ -25,6 +26,8 @@ write_dataframe_to_db(
 
 \item{dataframe}{Source R dataframe that will be written to SQL Server database.}
 
+\item{append_to_existing}{Boolean if TRUE then rows will be appended to existing database table (if exists). Default FALSE.}
+
 \item{batch_size}{Source R dataframe rows will be loaded into a staging SQL Server table in batches of this many rows at a time.}
 
 \item{versioned_table}{Create table with SQL Server system versioning. Defaults to TRUE. If table already exists in DB will not change existing versioning status.}
@@ -33,5 +36,5 @@ write_dataframe_to_db(
 Write an R dataframe to SQL Server table optionally with system versioning on.
 }
 \examples{
-write_dataframe_to_db(server = "my_server", schema = "my_schema", table_name = "output_table", dataframe = my_df, versioned_table = TRUE)
+write_dataframe_to_db(server = "my_server", schema = "my_schema", table_name = "output_table", dataframe = my_df)
 }

--- a/man/write_dataframe_to_db.Rd
+++ b/man/write_dataframe_to_db.Rd
@@ -30,7 +30,7 @@ write_dataframe_to_db(
 
 \item{batch_size}{Source R dataframe rows will be loaded into a staging SQL Server table in batches of this many rows at a time.}
 
-\item{versioned_table}{Create table with SQL Server system versioning. Defaults to TRUE. If table already exists in DB will not change existing versioning status.}
+\item{versioned_table}{Create table with SQL Server system versioning. Defaults to FALSE. If table already exists in DB will not change existing versioning status.}
 }
 \description{
 Write an R dataframe to SQL Server table optionally with system versioning on.


### PR DESCRIPTION
- Changes to allow an append argument in `write_dataframe_to_db`
- Replacing existing table process consists of delete and recreate table, not truncate so no column type checks.